### PR TITLE
Updated shaders to use glam functions for making vecs

### DIFF
--- a/shaders/src/a_lot_of_spheres.rs
+++ b/shaders/src/a_lot_of_spheres.rs
@@ -12,7 +12,7 @@
 //! ```
 
 use shared::*;
-use spirv_std::glam::{const_mat2, Mat2, Vec2, Vec3, Vec3Swizzles, Vec4};
+use spirv_std::glam::{const_mat2, vec2, vec3, Mat2, Vec2, Vec3, Vec3Swizzles, Vec4};
 
 // Note: This cfg is incorrect on its surface, it really should be "are we compiling with std", but
 // we tie #[no_std] above to the same condition, so it's fine.
@@ -46,16 +46,16 @@ fn hash(n: f32) -> f32 {
     (n.sin() * 43758.5453).gl_fract()
 }
 fn _hash2(n: f32) -> Vec2 {
-    (Vec2::new(n, n + 1.0).sin() * Vec2::new(2.1459123, 3.3490423)).gl_fract()
+    (vec2(n, n + 1.0).sin() * vec2(2.1459123, 3.3490423)).gl_fract()
 }
 fn hash2_vec(n: Vec2) -> Vec2 {
-    (Vec2::new(n.x * n.y, n.x + n.y).sin() * Vec2::new(2.1459123, 3.3490423)).gl_fract()
+    (vec2(n.x * n.y, n.x + n.y).sin() * vec2(2.1459123, 3.3490423)).gl_fract()
 }
 fn _hash3(n: f32) -> Vec3 {
-    (Vec3::new(n, n + 1.0, n + 2.0).sin() * Vec3::new(3.5453123, 4.1459123, 1.3490423)).gl_fract()
+    (vec3(n, n + 1.0, n + 2.0).sin() * vec3(3.5453123, 4.1459123, 1.3490423)).gl_fract()
 }
 fn hash3_vec(n: Vec2) -> Vec3 {
-    (Vec3::new(n.x, n.y, n.x + 2.0).sin() * Vec3::new(3.5453123, 4.1459123, 1.3490423)).gl_fract()
+    (vec3(n.x, n.y, n.x + 2.0).sin() * vec3(3.5453123, 4.1459123, 1.3490423)).gl_fract()
 }
 
 //
@@ -98,7 +98,7 @@ fn intersect_unit_sphere(ro: Vec3, rd: Vec3, sph: Vec3, dist: &mut f32, normal: 
 //
 
 fn get_sphere_offset(grid: Vec2, center: &mut Vec2) {
-    *center = (hash2_vec(grid + Vec2::new(43.12, 1.23)) - Vec2::splat(0.5)) * (GRIDSIZESMALL);
+    *center = (hash2_vec(grid + vec2(43.12, 1.23)) - Vec2::splat(0.5)) * (GRIDSIZESMALL);
 }
 
 impl Inputs {
@@ -110,15 +110,15 @@ impl Inputs {
         let y: f32 = s * MAXHEIGHT * (4.0 * t * (1. - t)).abs();
         let offset: Vec2 = grid + sphere_offset;
 
-        *center = Vec3::new(offset.x, y, offset.y) + 0.5 * Vec3::new(GRIDSIZE, 2.0, GRIDSIZE);
+        *center = vec3(offset.x, y, offset.y) + 0.5 * vec3(GRIDSIZE, 2.0, GRIDSIZE);
     }
 }
 fn get_sphere_position(grid: Vec2, sphere_offset: Vec2, center: &mut Vec3) {
     let offset: Vec2 = grid + sphere_offset;
-    *center = Vec3::new(offset.x, 0.0, offset.y) + 0.5 * Vec3::new(GRIDSIZE, 2.0, GRIDSIZE);
+    *center = vec3(offset.x, 0.0, offset.y) + 0.5 * vec3(GRIDSIZE, 2.0, GRIDSIZE);
 }
 fn get_sphere_color(grid: Vec2) -> Vec3 {
-    hash3_vec(grid + Vec2::new(43.12 * grid.y, 12.23 * grid.x)).normalize()
+    hash3_vec(grid + vec2(43.12 * grid.y, 12.23 * grid.x)).normalize()
 }
 
 impl Inputs {
@@ -141,7 +141,7 @@ impl Inputs {
         if intersect_plane(ro, rd, 0.0, &mut distcheck) && distcheck < MAXDISTANCE {
             *dist = distcheck;
             *material = 1;
-            *normal = Vec3::new(0.0, 1.0, 0.0);
+            *normal = vec3(0.0, 1.0, 0.0);
             col = Vec3::one();
         } else {
             col = Vec3::zero();
@@ -194,13 +194,12 @@ impl Inputs {
 
             if *material == 1 || *material == 3 {
                 // lightning
-                let c: Vec3 = Vec3::new(-GRIDSIZE, 0.0, GRIDSIZE);
+                let c: Vec3 = vec3(-GRIDSIZE, 0.0, GRIDSIZE);
                 let mut x = 0;
                 while x < 3 {
                     let mut y = 0;
                     while y < 3 {
-                        let mapoffset: Vec2 =
-                            map + Vec2::new([c.x, c.y, c.z][x], [c.x, c.y, c.z][y]);
+                        let mapoffset: Vec2 = map + vec2([c.x, c.y, c.z][x], [c.x, c.y, c.z][y]);
                         let mut offset: Vec2 = Vec2::zero();
                         get_sphere_offset(mapoffset, &mut offset);
                         let lcolor: Vec3 = get_sphere_color(mapoffset);
@@ -220,7 +219,7 @@ impl Inputs {
                                     }
 
                                     let smapoffset: Vec2 =
-                                        map + Vec2::new([c.x, c.y, c.z][x], [c.x, c.y, c.z][y]);
+                                        map + vec2([c.x, c.y, c.z][x], [c.x, c.y, c.z][y]);
                                     let mut soffset: Vec2 = Vec2::zero();
                                     get_sphere_offset(smapoffset, &mut soffset);
                                     let mut slpos: Vec3 = Vec3::zero();
@@ -252,7 +251,7 @@ impl Inputs {
                 }
             } else {
                 // emitter
-                color = (1.5 + normal.dot(Vec3::new(0.5, 0.5, -0.5))) * get_sphere_color(map);
+                color = (1.5 + normal.dot(vec3(0.5, 0.5, -0.5))) * get_sphere_color(map);
             }
         }
         color
@@ -264,14 +263,14 @@ impl Inputs {
         p.x *= self.resolution.x / self.resolution.y;
 
         // camera
-        let ce: Vec3 = Vec3::new(
+        let ce: Vec3 = vec3(
             (0.232 * self.time).cos() * 10.0,
             6. + 3.0 * (0.3 * self.time).cos(),
             GRIDSIZE * (self.time / SPEED),
         );
         let ro: Vec3 = ce;
         let ta: Vec3 = ro
-            + Vec3::new(
+            + vec3(
                 -(0.232 * self.time).sin() * 10.,
                 -2.0 + (0.23 * self.time).cos(),
                 10.0,
@@ -280,7 +279,7 @@ impl Inputs {
         let roll: f32 = -0.15 * (0.5 * self.time).sin();
         // camera tx
         let cw: Vec3 = (ta - ro).normalize();
-        let cp: Vec3 = Vec3::new(roll.sin(), roll.cos(), 0.0);
+        let cp: Vec3 = vec3(roll.sin(), roll.cos(), 0.0);
         let cu: Vec3 = (cw.cross(cp)).normalize();
         let cv: Vec3 = (cu.cross(cw)).normalize();
         let mut rd: Vec3 = (p.x * cu + p.y * cv + 1.5 * cw).normalize();
@@ -312,7 +311,7 @@ impl Inputs {
                 );
         }
 
-        col = col.powf_vec(Vec3::new(EXPOSURE, EXPOSURE, EXPOSURE));
+        col = col.powf_vec(vec3(EXPOSURE, EXPOSURE, EXPOSURE));
         col = col.clamp(Vec3::zero(), Vec3::one());
         // vigneting
         col *= 0.25 + 0.75 * (16.0 * q.x * q.y * (1.0 - q.x) * (1.0 - q.y)).powf(0.15);

--- a/shaders/src/a_question_of_time.rs
+++ b/shaders/src/a_question_of_time.rs
@@ -27,7 +27,9 @@
 //! ```
 
 use shared::*;
-use spirv_std::glam::{Mat2, Vec2, Vec2Swizzles, Vec3, Vec3Swizzles, Vec4, Vec4Swizzles};
+use spirv_std::glam::{
+    vec2, vec3, Mat2, Vec2, Vec2Swizzles, Vec3, Vec3Swizzles, Vec4, Vec4Swizzles,
+};
 
 // Note: This cfg is incorrect on its surface, it really should be "are we compiling with std", but
 // we tie #[no_std] above to the same condition, so it's fine.
@@ -60,7 +62,7 @@ fn stroke(d: f32, w: f32, s: f32, i: f32) -> f32 {
 }
 // a simple palette
 fn pal(d: f32) -> Vec3 {
-    0.5 * ((6.283 * d * Vec3::new(2.0, 2.0, 1.0) + Vec3::new(0.0, 1.4, 0.0)).cos() + Vec3::one())
+    0.5 * ((6.283 * d * vec3(2.0, 2.0, 1.0) + vec3(0.0, 1.4, 0.0)).cos() + Vec3::one())
 }
 // 2d rotation matrix
 fn uvr_rotate(a: f32) -> Mat2 {
@@ -72,7 +74,7 @@ fn inversion(uv: Vec2, r: f32) -> Vec2 {
 }
 // seeded random number
 fn hash(s: Vec2) -> f32 {
-    ((s.dot(Vec2::new(12.9898, 78.2333))).sin() * 43758.5453123).gl_fract()
+    ((s.dot(vec2(12.9898, 78.2333))).sin() * 43758.5453123).gl_fract()
 }
 
 // this is an algorithm to construct an apollonian packing with a descartes configuration
@@ -88,12 +90,12 @@ fn apollonian(uv: Vec2) -> Vec3 {
     let a: f32 = 6.283 / 3.;
     let ra: f32 = 1.0 + (a * 0.5).sin();
     let rb: f32 = 1.0 - (a * 0.5).sin();
-    dec[0] = Vec3::new(0.0, 0.0, -1.0 / ra);
+    dec[0] = vec3(0.0, 0.0, -1.0 / ra);
     let radius: f32 = 0.5 * (ra - rb);
     let bend: f32 = 1.0 / radius;
     let mut i = 1;
     while i < 4 {
-        dec[i] = Vec3::new((i as f32 * a).cos(), (i as f32 * a).sin(), bend);
+        dec[i] = vec3((i as f32 * a).cos(), (i as f32 * a).sin(), bend);
         // if the point is in one of the starting circles we have already found our solution
         if (uv - dec[i].xy()).length() < radius {
             return (uv - dec[i].xy()).extend(radius);
@@ -232,8 +234,8 @@ impl Inputs {
                 pal(0.85),
                 stroke(
                     sdf_rect(
-                        uvrh + Vec2::new(uv_apo.z - (uv_apo.z * 0.8), 0.0),
-                        uv_apo.z * Vec2::new(0.4, 0.03),
+                        uvrh + vec2(uv_apo.z - (uv_apo.z * 0.8), 0.0),
+                        uv_apo.z * vec2(0.4, 0.03),
                     ),
                     uv_apo.z * 0.01,
                     0.005,
@@ -245,8 +247,8 @@ impl Inputs {
                 pal(0.9),
                 fill(
                     sdf_rect(
-                        uvrm + Vec2::new(uv_apo.z - (uv_apo.z * 0.65), 0.0),
-                        uv_apo.z * Vec2::new(0.5, 0.002),
+                        uvrm + vec2(uv_apo.z - (uv_apo.z * 0.65), 0.0),
+                        uv_apo.z * vec2(0.5, 0.002),
                     ),
                     0.005,
                     1.0,
@@ -275,7 +277,7 @@ impl Inputs {
                 0.05,
                 1.0,
             );
-            let size: Vec2 = uv_apo.z * Vec2::new(0.45, 0.08);
+            let size: Vec2 = uv_apo.z * vec2(0.45, 0.08);
             c = mix(
                 c,
                 pal(0.55 - r * 0.6),
@@ -293,7 +295,7 @@ impl Inputs {
             );
         // drawing the screws
         } else {
-            let size: Vec2 = uv_apo.z * Vec2::new(0.5, 0.1);
+            let size: Vec2 = uv_apo.z * vec2(0.5, 0.1);
             c = mix(
                 c,
                 pal(0.85 - (uv_apo.z * 2.0)),

--- a/shaders/src/apollonian.rs
+++ b/shaders/src/apollonian.rs
@@ -11,7 +11,7 @@
 //! ```
 
 use shared::*;
-use spirv_std::glam::{Vec2, Vec2Swizzles, Vec3, Vec3Swizzles, Vec4};
+use spirv_std::glam::{vec2, vec3, Vec2, Vec2Swizzles, Vec3, Vec3Swizzles, Vec4};
 
 // Note: This cfg is incorrect on its surface, it really should be "are we compiling with std", but
 // we tie #[no_std] above to the same condition, so it's fine.
@@ -91,7 +91,7 @@ impl State {
     fn calc_normal(&mut self, pos: Vec3, t: f32, s: f32) -> Vec3 {
         let precis: f32 = 0.001 * t;
 
-        let e: Vec2 = Vec2::new(1.0, -1.0) * precis;
+        let e: Vec2 = vec2(1.0, -1.0) * precis;
         (e.xyy() * self.map(pos + e.xyy(), s)
             + e.yyx() * self.map(pos + e.yyx(), s)
             + e.yxy() * self.map(pos + e.yxy(), s)
@@ -109,27 +109,23 @@ impl State {
             let nor: Vec3 = self.calc_normal(pos, t, anim);
 
             // lighting
-            let light1: Vec3 = Vec3::new(0.577, 0.577, -0.577);
-            let light2: Vec3 = Vec3::new(-0.707, 0.000, 0.707);
+            let light1: Vec3 = vec3(0.577, 0.577, -0.577);
+            let light2: Vec3 = vec3(-0.707, 0.000, 0.707);
             let key: f32 = light1.dot(nor).clamp(0.0, 1.0);
             let bac: f32 = (0.2 + 0.8 * light2.dot(nor)).clamp(0.0, 1.0);
             let amb: f32 = 0.7 + 0.3 * nor.y;
             let ao: f32 = (tra.w * 2.0).clamp(0.0, 1.0).powf(1.2);
 
-            let mut brdf: Vec3 = 1.0 * Vec3::new(0.40, 0.40, 0.40) * amb * ao;
-            brdf += 1.0 * Vec3::new(1.00, 1.00, 1.00) * key * ao;
-            brdf += 1.0 * Vec3::new(0.40, 0.40, 0.40) * bac * ao;
+            let mut brdf: Vec3 = 1.0 * vec3(0.40, 0.40, 0.40) * amb * ao;
+            brdf += 1.0 * vec3(1.00, 1.00, 1.00) * key * ao;
+            brdf += 1.0 * vec3(0.40, 0.40, 0.40) * bac * ao;
 
             // material
             let mut rgb: Vec3 = Vec3::one();
+            rgb = mix(rgb, vec3(1.0, 0.80, 0.2), (6.0 * tra.y).clamp(0.0, 1.0));
             rgb = mix(
                 rgb,
-                Vec3::new(1.0, 0.80, 0.2),
-                (6.0 * tra.y).clamp(0.0, 1.0),
-            );
-            rgb = mix(
-                rgb,
-                Vec3::new(1.0, 0.55, 0.0),
+                vec3(1.0, 0.55, 0.0),
                 (1.0 - 2.0 * tra.z).clamp(0.0, 1.0).powf(8.0),
             );
 
@@ -149,23 +145,23 @@ impl State {
         while jj < AA {
             let mut ii = 0;
             while ii < AA {
-                let q: Vec2 = frag_coord + Vec2::new(ii as f32, jj as f32) / AA as f32;
+                let q: Vec2 = frag_coord + vec2(ii as f32, jj as f32) / AA as f32;
                 let p: Vec2 = (2.0 * q - self.inputs.resolution.xy()) / self.inputs.resolution.y;
 
                 // camera
-                let ro: Vec3 = Vec3::new(
+                let ro: Vec3 = vec3(
                     2.8 * (0.1 + 0.33 * time).cos(),
                     0.4 + 0.30 * (0.37 * time).cos(),
                     2.8 * (0.5 + 0.35 * time).cos(),
                 );
-                let ta: Vec3 = Vec3::new(
+                let ta: Vec3 = vec3(
                     1.9 * (1.2 + 0.41 * time).cos(),
                     0.4 + 0.10 * (0.27 * time).cos(),
                     1.9 * (2.0 + 0.38 * time).cos(),
                 );
                 let roll: f32 = 0.2 * (0.1 * time).cos();
                 let cw: Vec3 = (ta - ro).normalize();
-                let cp: Vec3 = Vec3::new(roll.sin(), roll.cos(), 0.0);
+                let cp: Vec3 = vec3(roll.sin(), roll.cos(), 0.0);
                 let cu: Vec3 = cw.cross(cp).normalize();
                 let cv: Vec3 = cu.cross(cw).normalize();
                 let rd: Vec3 = (p.x * cu + p.y * cv + 2.0 * cw).normalize();
@@ -191,11 +187,7 @@ impl State {
         let _time: f32 = self.inputs.time * 0.25 + 0.01 * self.inputs.mouse.x;
         let anim: f32 = 1.1 + 0.5 * smoothstep(-0.3, 0.3, (0.1 * self.inputs.time).cos());
 
-        let col: Vec3 = self.render(
-            frag_ray_ori + Vec3::new(0.82, 1.2, -0.3),
-            freag_ray_dir,
-            anim,
-        );
+        let col: Vec3 = self.render(frag_ray_ori + vec3(0.82, 1.2, -0.3), freag_ray_dir, anim);
         *frag_color = col.extend(1.0);
     }
 }

--- a/shaders/src/clouds.rs
+++ b/shaders/src/clouds.rs
@@ -1,7 +1,7 @@
 //! Ported to Rust from <https://www.shadertoy.com/view/4tdSWr>
 
 use shared::*;
-use spirv_std::glam::{const_mat2, const_vec3, Mat2, Vec2, Vec3, Vec3Swizzles, Vec4};
+use spirv_std::glam::{const_mat2, const_vec3, vec2, vec3, Mat2, Vec2, Vec3, Vec3Swizzles, Vec4};
 
 // Note: This cfg is incorrect on its surface, it really should be "are we compiling with std", but
 // we tie #[no_std] above to the same condition, so it's fine.
@@ -26,10 +26,7 @@ const SKY_COLOUR2: Vec3 = const_vec3!([0.4, 0.7, 1.0]);
 const M: Mat2 = const_mat2!([1.6, 1.2, -1.2, 1.6]);
 
 fn hash(mut p: Vec2) -> Vec2 {
-    p = Vec2::new(
-        p.dot(Vec2::new(127.1, 311.7)),
-        p.dot(Vec2::new(269.5, 183.3)),
-    );
+    p = vec2(p.dot(vec2(127.1, 311.7)), p.dot(vec2(269.5, 183.3)));
     Vec2::splat(-1.0) + 2.0 * (p.sin() * 43758.5453123).gl_fract()
 }
 
@@ -39,15 +36,15 @@ fn noise(p: Vec2) -> f32 {
     let i: Vec2 = (p + Vec2::splat((p.x + p.y) * K1)).floor();
     let a: Vec2 = p - i + Vec2::splat((i.x + i.y) * K2);
     let o: Vec2 = if a.x > a.y {
-        Vec2::new(1.0, 0.0)
+        vec2(1.0, 0.0)
     } else {
-        Vec2::new(0.0, 1.0)
+        vec2(0.0, 1.0)
     }; //vec2 of = 0.5 + 0.5*vec2(sign(a.x-a.y), sign(a.y-a.x));
     let b: Vec2 = a - o + Vec2::splat(K2);
     let c: Vec2 = a - Vec2::splat(1.0 - 2.0 * K2);
-    let h: Vec3 = (Vec3::splat(0.5) - Vec3::new(a.dot(a), b.dot(b), c.dot(c))).max(Vec3::zero());
+    let h: Vec3 = (Vec3::splat(0.5) - vec3(a.dot(a), b.dot(b), c.dot(c))).max(Vec3::zero());
     let n: Vec3 = (h * h * h * h)
-        * Vec3::new(
+        * vec3(
             a.dot(hash(i + Vec2::zero())),
             b.dot(hash(i + o)),
             c.dot(hash(i + Vec2::splat(1.0))),
@@ -74,7 +71,7 @@ fn fbm(mut n: Vec2) -> f32 {
 impl Inputs {
     pub fn main_image(&self, frag_color: &mut Vec4, frag_coord: Vec2) {
         let p: Vec2 = frag_coord / self.resolution.xy();
-        let mut uv: Vec2 = p * Vec2::new(self.resolution.x / self.resolution.y, 1.0);
+        let mut uv: Vec2 = p * vec2(self.resolution.x / self.resolution.y, 1.0);
         let mut time: f32 = self.time * SPEED;
         let q: f32 = fbm(uv * CLOUD_SCALE * 0.5);
 
@@ -94,7 +91,7 @@ impl Inputs {
 
         //noise shape
         let mut f: f32 = 0.0;
-        uv = p * Vec2::new(self.resolution.x / self.resolution.y, 1.0);
+        uv = p * vec2(self.resolution.x / self.resolution.y, 1.0);
         uv *= CLOUD_SCALE;
         uv -= Vec2::splat(q - time);
         weight = 0.7;
@@ -112,7 +109,7 @@ impl Inputs {
         //noise colour
         let mut c: f32 = 0.0;
         time = self.time * SPEED * 2.0;
-        uv = p * Vec2::new(self.resolution.x / self.resolution.y, 1.0);
+        uv = p * vec2(self.resolution.x / self.resolution.y, 1.0);
         uv *= CLOUD_SCALE * 2.0;
         uv -= Vec2::splat(q - time);
         weight = 0.4;
@@ -128,7 +125,7 @@ impl Inputs {
         //noise ridge colour
         let mut c1: f32 = 0.0;
         time = self.time * SPEED * 3.0;
-        uv = p * Vec2::new(self.resolution.x / self.resolution.y, 1.0);
+        uv = p * vec2(self.resolution.x / self.resolution.y, 1.0);
         uv *= CLOUD_SCALE * 3.0;
         uv -= Vec2::splat(q - time);
         weight = 0.4;
@@ -145,7 +142,7 @@ impl Inputs {
 
         let skycolour: Vec3 = mix(SKY_COLOUR2, SKY_COLOUR1, p.y);
         let cloudcolour: Vec3 =
-            Vec3::new(1.1, 1.1, 0.9) * (CLOUD_DARK + CLOUD_LIGHT * c).clamp(0.0, 1.0);
+            vec3(1.1, 1.1, 0.9) * (CLOUD_DARK + CLOUD_LIGHT * c).clamp(0.0, 1.0);
 
         f = CLOUD_COVER + CLOUD_ALPHA * f * r;
 

--- a/shaders/src/galaxy_of_universes.rs
+++ b/shaders/src/galaxy_of_universes.rs
@@ -10,7 +10,7 @@
 //! ```
 
 use shared::*;
-use spirv_std::glam::{Mat2, Vec2, Vec3, Vec3Swizzles, Vec4};
+use spirv_std::glam::{vec3, Mat2, Vec2, Vec3, Vec3Swizzles, Vec4};
 
 // Note: This cfg is incorrect on its surface, it really should be "are we compiling with std", but
 // we tie #[no_std] above to the same condition, so it's fine.
@@ -40,7 +40,7 @@ impl Inputs {
         while i < 90 {
             let mut p: Vec3 = s * uv.extend(0.0);
             p = (ma.transpose() * p.xy()).extend(p.z);
-            p += Vec3::new(0.22, 0.3, s - 1.5 - (self.time * 0.13).sin() * 0.1);
+            p += vec3(0.22, 0.3, s - 1.5 - (self.time * 0.13).sin() * 0.1);
             {
                 let mut i = 0;
                 while i < 8 {
@@ -60,7 +60,7 @@ impl Inputs {
         v2 *= smoothstep(0.5, 0.0, len);
         v3 *= smoothstep(0.9, 0.0, len);
 
-        let col: Vec3 = Vec3::new(
+        let col: Vec3 = vec3(
             v3 * (1.5 + (self.time * 0.2).sin() * 0.4),
             (v1 + v3) * 0.3,
             v2,

--- a/shaders/src/heart.rs
+++ b/shaders/src/heart.rs
@@ -7,7 +7,7 @@
 //! ```
 
 use shared::*;
-use spirv_std::glam::{Vec2, Vec3, Vec3Swizzles, Vec4};
+use spirv_std::glam::{vec2, vec3, Vec2, Vec3, Vec3Swizzles, Vec4};
 
 // Note: This cfg is incorrect on its surface, it really should be "are we compiling with std", but
 // we tie #[no_std] above to the same condition, so it's fine.
@@ -25,13 +25,13 @@ impl Inputs {
             (2.0 * frag_coord - self.resolution.xy()) / (self.resolution.y.min(self.resolution.x));
 
         // background color
-        let bcol: Vec3 = Vec3::new(1.0, 0.8, 0.7 - 0.07 * p.y) * (1.0 - 0.25 * p.length());
+        let bcol: Vec3 = vec3(1.0, 0.8, 0.7 - 0.07 * p.y) * (1.0 - 0.25 * p.length());
 
         // animate
         let tt: f32 = self.time.rem_euclid(1.5) / 1.5;
         let mut ss: f32 = tt.powf(0.2) * 0.5 + 0.5;
         ss = 1.0 + ss * 0.5 * (tt * 6.2831 * 3.0 + p.y * 0.5).sin() * (-tt * 4.0).exp();
-        p *= Vec2::new(0.5, 1.5) + ss * Vec2::new(0.5, -0.5);
+        p *= vec2(0.5, 1.5) + ss * vec2(0.5, -0.5);
 
         // shape
         let r: f32;
@@ -55,7 +55,7 @@ impl Inputs {
         s *= 1.0 - 0.4 * r;
         s = 0.3 + 0.7 * s;
         s *= 0.5 + 0.5 * (1.0 - (r / d).clamp(0.0, 1.0)).powf(0.1);
-        let hcol: Vec3 = Vec3::new(1.0, 0.5 * r, 0.3) * s;
+        let hcol: Vec3 = vec3(1.0, 0.5 * r, 0.3) * s;
 
         let col: Vec3 = mix(bcol, hcol, smoothstep(-0.01, 0.01, d - r));
 

--- a/shaders/src/lib.rs
+++ b/shaders/src/lib.rs
@@ -4,7 +4,7 @@
 #![register_attr(spirv)]
 
 use shared::*;
-use spirv_std::glam::{Vec2, Vec3, Vec4};
+use spirv_std::glam::{vec2, vec3, Vec2, Vec3, Vec4};
 use spirv_std::storage_class::{Input, Output, PushConstant};
 
 pub mod a_lot_of_spheres;
@@ -51,7 +51,7 @@ pub fn fs(constants: &ShaderConstants, mut frag_coord: Vec2) -> Vec4 {
     const COLS: usize = 4;
     const ROWS: usize = 4;
 
-    let resolution = Vec3::new(
+    let resolution = vec3(
         constants.width as f32 / COLS as f32,
         constants.height as f32 / ROWS as f32,
         0.0,
@@ -121,7 +121,7 @@ pub fn main_fs(
 ) {
     let constants = constants.load();
 
-    let frag_coord = Vec2::new(in_frag_coord.load().x, in_frag_coord.load().y);
+    let frag_coord = vec2(in_frag_coord.load().x, in_frag_coord.load().y);
     let color = fs(&constants, frag_coord);
     output.store(color);
 }
@@ -136,7 +136,7 @@ pub fn main_vs(
 
     // Create a "full screen triangle" by mapping the vertex index.
     // ported from https://www.saschawillems.de/blog/2016/08/13/vulkan-tutorial-on-rendering-a-fullscreen-quad-without-buffers/
-    let uv = Vec2::new(((vert_idx << 1) & 2) as f32, (vert_idx & 2) as f32);
+    let uv = vec2(((vert_idx << 1) & 2) as f32, (vert_idx & 2) as f32);
     let pos = 2.0 * uv - Vec2::one();
 
     builtin_pos.store(pos.extend(0.0).extend(1.0));

--- a/shaders/src/mandelbrot_smooth.rs
+++ b/shaders/src/mandelbrot_smooth.rs
@@ -11,7 +11,7 @@
 //! ```
 
 use shared::*;
-use spirv_std::glam::{Vec2, Vec3, Vec3Swizzles, Vec4};
+use spirv_std::glam::{vec2, vec3, Vec2, Vec3, Vec3Swizzles, Vec4};
 
 // Note: This cfg is incorrect on its surface, it really should be "are we compiling with std", but
 // we tie #[no_std] above to the same condition, so it's fine.
@@ -44,7 +44,7 @@ impl Inputs {
         let mut z: Vec2 = Vec2::zero();
         let mut i = 0;
         while i < 512 {
-            z = Vec2::new(z.x * z.x - z.y * z.y, 2.0 * z.x * z.y) + c;
+            z = vec2(z.x * z.x - z.y * z.y, 2.0 * z.x * z.y) + c;
             if z.dot(z) > (B * B) {
                 break;
             }
@@ -74,7 +74,7 @@ impl Inputs {
             let mut n = 0;
             while n < AA {
                 let p: Vec2 = (-self.resolution.xy()
-                    + Vec2::splat(2.0) * (frag_coord + Vec2::new(m as f32, n as f32) / AA as f32))
+                    + Vec2::splat(2.0) * (frag_coord + vec2(m as f32, n as f32) / AA as f32))
                     / self.resolution.y;
                 let w: f32 = (AA * m + n) as f32;
                 let time: f32 = self.time + 0.5 * (1.0 / 24.0) * w / (AA * AA) as f32;
@@ -83,13 +83,12 @@ impl Inputs {
                 let coa: f32 = (0.15 * (1.0 - zoo) * time).cos();
                 let sia = (0.15 * (1.0 - zoo) * time).sin();
                 zoo = zoo.powf(8.0);
-                let xy: Vec2 = Vec2::new(p.x * coa - p.y * sia, p.x * sia + p.y * coa);
-                let c: Vec2 = Vec2::new(-0.745, 0.186) + xy * zoo;
+                let xy: Vec2 = vec2(p.x * coa - p.y * sia, p.x * sia + p.y * coa);
+                let c: Vec2 = vec2(-0.745, 0.186) + xy * zoo;
 
                 let l: f32 = self.mandelbrot(c);
                 col += Vec3::splat(0.5)
-                    + Vec3::splat(0.5)
-                        * (Vec3::splat(3.0 + l * 0.15) + Vec3::new(0.0, 0.6, 1.0)).cos();
+                    + Vec3::splat(0.5) * (Vec3::splat(3.0 + l * 0.15) + vec3(0.0, 0.6, 1.0)).cos();
                 n += 1;
             }
             m += 1;

--- a/shaders/src/phantom_star.rs
+++ b/shaders/src/phantom_star.rs
@@ -1,6 +1,6 @@
 //! Ported to Rust from <https://www.shadertoy.com/view/ttKGDt>
 
-use spirv_std::glam::{Mat2, Vec2, Vec3, Vec3Swizzles, Vec4};
+use spirv_std::glam::{vec3, Mat2, Vec2, Vec3, Vec3Swizzles, Vec4};
 
 use core::f32::consts::PI;
 
@@ -48,7 +48,7 @@ impl Inputs {
             i += 1;
         }
         p = (rot(self.time).transpose() * p.xz()).extend(p.y).xzy();
-        box_(p, Vec3::new(0.4, 0.8, 0.3))
+        box_(p, vec3(0.4, 0.8, 0.3))
     }
 
     fn map(&self, p: Vec3, _c_pos: Vec3) -> f32 {
@@ -64,10 +64,10 @@ impl Inputs {
         let p: Vec2 =
             (frag_coord * 2.0 - self.resolution.xy()) / self.resolution.x.min(self.resolution.y);
 
-        let c_pos: Vec3 = Vec3::new(0.0, 0.0, -3.0 * self.time);
-        // let c_pos: Vec3 = Vec3::new(0.3 * (self.time * 0.8).sin(), 0.4 * (self.time * 0.3).cos(), -6.0 * self.time,);
-        let c_dir: Vec3 = Vec3::new(0.0, 0.0, -1.0).normalize();
-        let c_up: Vec3 = Vec3::new(self.time.sin(), 1.0, 0.0);
+        let c_pos: Vec3 = vec3(0.0, 0.0, -3.0 * self.time);
+        // let c_pos: Vec3 = vec3(0.3 * (self.time * 0.8).sin(), 0.4 * (self.time * 0.3).cos(), -6.0 * self.time,);
+        let c_dir: Vec3 = vec3(0.0, 0.0, -1.0).normalize();
+        let c_up: Vec3 = vec3(self.time.sin(), 1.0, 0.0);
         let c_side: Vec3 = c_dir.cross(c_up);
 
         let ray: Vec3 = (c_side * p.x + c_up * p.y + c_dir).normalize();
@@ -92,7 +92,7 @@ impl Inputs {
             i += 1;
         }
 
-        let col: Vec3 = Vec3::new(
+        let col: Vec3 = vec3(
             acc * 0.01,
             acc * 0.011 + acc2 * 0.002,
             acc * 0.012 + acc2 * 0.005,

--- a/shaders/src/playing_marble.rs
+++ b/shaders/src/playing_marble.rs
@@ -8,7 +8,7 @@
 
 use crate::Channel;
 use shared::*;
-use spirv_std::glam::{Mat2, Vec2, Vec3, Vec3Swizzles, Vec4, Vec4Swizzles};
+use spirv_std::glam::{vec2, vec3, Mat2, Vec2, Vec3, Vec3Swizzles, Vec4, Vec4Swizzles};
 
 // Note: This cfg is incorrect on its surface, it really should be "are we compiling with std", but
 // we tie #[no_std] above to the same condition, so it's fine.
@@ -25,10 +25,10 @@ pub struct Inputs<C0> {
 const ZOOM: f32 = 1.0;
 
 fn _cmul(a: Vec2, b: Vec2) -> Vec2 {
-    Vec2::new(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x)
+    vec2(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x)
 }
 fn csqr(a: Vec2) -> Vec2 {
-    Vec2::new(a.x * a.x - a.y * a.y, 2. * a.x * a.y)
+    vec2(a.x * a.x - a.y * a.y, 2. * a.x * a.y)
 }
 
 fn rot(a: f32) -> Mat2 {
@@ -45,7 +45,7 @@ fn i_sphere(ro: Vec3, rd: Vec3, sph: Vec4) -> Vec2 {
         return Vec2::splat(-1.0);
     }
     h = h.sqrt();
-    Vec2::new(-b - h, -b + h)
+    vec2(-b - h, -b + h)
 }
 
 fn map(mut p: Vec3) -> f32 {
@@ -79,9 +79,9 @@ impl<C0: Channel> Inputs<C0> {
 
             c = map(ro + t * rd);
 
-            col = 0.99 * col + 0.08 * Vec3::new(c * c, c, c * c * c); //green
+            col = 0.99 * col + 0.08 * vec3(c * c, c, c * c * c); //green
 
-            // col = 0.99 * col + 0.08 * Vec3::new(c * c * c, c * c, c); //blue
+            // col = 0.99 * col + 0.08 * vec3(c * c * c, c * c, c); //blue
             i += 1;
         }
         col
@@ -106,7 +106,7 @@ impl<C0: Channel> Inputs<C0> {
             .xzy();
         let ta: Vec3 = Vec3::zero();
         let ww: Vec3 = (ta - ro).normalize();
-        let uu: Vec3 = (ww.cross(Vec3::new(0.0, 1.0, 0.0))).normalize();
+        let uu: Vec3 = (ww.cross(vec3(0.0, 1.0, 0.0))).normalize();
         let vv: Vec3 = (uu.cross(ww)).normalize();
         let rd: Vec3 = (p.x * uu + p.y * vv + 4.0 * ww).normalize();
 

--- a/shaders/src/protean_clouds.rs
+++ b/shaders/src/protean_clouds.rs
@@ -27,7 +27,9 @@
 //! ```
 
 use shared::*;
-use spirv_std::glam::{const_mat3, Mat2, Mat3, Vec2, Vec3, Vec3Swizzles, Vec4, Vec4Swizzles};
+use spirv_std::glam::{
+    const_mat3, vec2, vec3, vec4, Mat2, Mat3, Vec2, Vec3, Vec3Swizzles, Vec4, Vec4Swizzles,
+};
 
 // Note: This cfg is incorrect on its surface, it really should be "are we compiling with std", but
 // we tie #[no_std] above to the same condition, so it's fine.
@@ -86,7 +88,7 @@ fn linstep(mn: f32, mx: f32, x: f32) -> f32 {
 }
 
 fn disp(t: f32) -> Vec2 {
-    Vec2::new((t * 0.22).sin() * 1.0, (t * 0.175).cos() * 1.0) * 2.0
+    vec2((t * 0.22).sin() * 1.0, (t * 0.175).cos() * 1.0) * 2.0
 }
 
 impl State {
@@ -116,7 +118,7 @@ impl State {
             i += 1;
         }
         d = (d + self.prm1 * 3.0).abs() + self.prm1 * 0.3 - 2.5 + self.bs_mo.y;
-        Vec2::new(d + cl * 0.2 + 0.25, cl)
+        vec2(d + cl * 0.2 + 0.25, cl)
     }
 
     fn render(&self, ro: Vec3, rd: Vec3, time: f32) -> Vec4 {
@@ -139,7 +141,7 @@ impl State {
 
             let mut col: Vec4 = Vec4::zero();
             if mpv.x > 0.6 {
-                col = ((Vec3::new(5.0, 0.4, 0.2)
+                col = ((vec3(5.0, 0.4, 0.2)
                     + Vec3::splat(mpv.y * 0.1 + (pos.z * 0.4).sin() * 0.5 + 1.8))
                 .sin()
                     * 0.5
@@ -152,12 +154,12 @@ impl State {
                 dif += ((den - self.map(pos + Vec3::splat(0.35)).x) / 2.5).clamp(0.001, 1.0);
                 col = (col.xyz()
                     * den
-                    * (Vec3::new(0.005, 0.045, 0.075) + 1.5 * Vec3::new(0.033, 0.07, 0.03) * dif))
+                    * (vec3(0.005, 0.045, 0.075) + 1.5 * vec3(0.033, 0.07, 0.03) * dif))
                     .extend(col.w);
             }
 
             let fog_c = (t * 0.2 - 2.2).exp();
-            col += Vec4::new(0.06, 0.11, 0.11, 0.1) * (fog_c - fog_t).clamp(0.0, 1.0);
+            col += vec4(0.06, 0.11, 0.11, 0.1) * (fog_c - fog_t).clamp(0.0, 1.0);
             fog_t = fog_c;
             rez = rez + col * (1.0 - rez.w);
             t += (0.5 - dn * dn * 0.05).clamp(0.09, 0.3);
@@ -177,9 +179,9 @@ fn getsat(c: Vec3) -> f32 {
 
 //from my "Will it blend" shader (https://www.shadertoy.com/view/lsdGzN)
 fn i_lerp(a: Vec3, b: Vec3, x: f32) -> Vec3 {
-    let mut ic: Vec3 = mix(a, b, x) + Vec3::new(1e-6, 0.0, 0.0);
+    let mut ic: Vec3 = mix(a, b, x) + vec3(1e-6, 0.0, 0.0);
     let sd: f32 = (getsat(ic) - mix(getsat(a), getsat(b), x)).abs();
-    let dir: Vec3 = Vec3::new(
+    let dir: Vec3 = vec3(
         2.0 * ic.x - ic.y - ic.z,
         2.0 * ic.y - ic.x - ic.z,
         2.0 * ic.z - ic.y - ic.x,
@@ -199,9 +201,9 @@ impl State {
             (self.inputs.mouse.xy() - 0.5 * self.inputs.resolution.xy()) / self.inputs.resolution.y;
 
         let time: f32 = self.inputs.time * 3.;
-        let mut ro: Vec3 = Vec3::new(0.0, 0.0, time);
+        let mut ro: Vec3 = vec3(0.0, 0.0, time);
 
-        ro += Vec3::new(
+        ro += vec3(
             self.inputs.time.sin() * 0.5,
             (self.inputs.time.sin() * 1.0) * 0.0,
             0.0,
@@ -214,7 +216,7 @@ impl State {
         let target: Vec3 =
             (ro - (disp(time + tgt_dst) * dsp_amp).extend(time + tgt_dst)).normalize();
         ro.x -= self.bs_mo.x * 2.;
-        let mut rightdir: Vec3 = target.cross(Vec3::new(0.0, 1.0, 0.0)).normalize();
+        let mut rightdir: Vec3 = target.cross(vec3(0.0, 1.0, 0.0)).normalize();
         let updir: Vec3 = rightdir.cross(target).normalize();
         rightdir = updir.cross(target).normalize();
         let mut rd: Vec3 = ((p.x * rightdir + p.y * updir) * 1.0 - target).normalize();
@@ -225,7 +227,7 @@ impl State {
         let mut col: Vec3 = scn.xyz();
         col = i_lerp(col.zyx(), col, (1.0 - self.prm1).clamp(0.05, 1.0));
 
-        col = col.powf_vec(Vec3::new(0.55, 0.65, 0.6)) * Vec3::new(1.0, 0.97, 0.9);
+        col = col.powf_vec(vec3(0.55, 0.65, 0.6)) * vec3(1.0, 0.97, 0.9);
 
         col *= (16.0 * q.x * q.y * (1.0 - q.x) * (1.0 - q.y)).powf(0.12) * 0.7 + 0.3; //Vign
 

--- a/shaders/src/tileable_water_caustic.rs
+++ b/shaders/src/tileable_water_caustic.rs
@@ -11,7 +11,7 @@
 //! ```
 
 use shared::*;
-use spirv_std::glam::{Vec2, Vec3, Vec3Swizzles, Vec4};
+use spirv_std::glam::{vec2, vec3, Vec2, Vec3, Vec3Swizzles, Vec4};
 
 // Note: This cfg is incorrect on its surface, it really should be "are we compiling with std", but
 // we tie #[no_std] above to the same condition, so it's fine.
@@ -47,12 +47,12 @@ impl Inputs {
         let mut n = 0;
         while n < MAX_ITER {
             let t: f32 = time * (1.1 - (3.5 / (n + 1) as f32));
-            i = p + Vec2::new(
+            i = p + vec2(
                 (t - i.x).cos() + (t + i.y).sin(),
                 (t - i.y).sin() + (t + i.x).cos(),
             );
             c += 1.0
-                / Vec2::new(
+                / vec2(
                     p.x / ((i.x + t).sin() / inten),
                     p.y / ((i.y + t).cos() / inten),
                 )
@@ -62,7 +62,7 @@ impl Inputs {
         c /= MAX_ITER as f32;
         c = 1.17 - c.powf(1.4);
         let mut colour: Vec3 = Vec3::splat(c.abs().powf(8.0));
-        colour = (colour + Vec3::new(0.0, 0.35, 0.5)).clamp(Vec3::zero(), Vec3::one());
+        colour = (colour + vec3(0.0, 0.35, 0.5)).clamp(Vec3::zero(), Vec3::one());
 
         if SHOW_TILING {
             let pixel: Vec2 = 2.0 / self.resolution.xy();
@@ -73,7 +73,7 @@ impl Inputs {
             uv = uv.gl_fract().step(pixel); // Add one line of pixels per tile.
             colour = mix(
                 colour,
-                Vec3::new(1.0, 1.0, 0.0),
+                vec3(1.0, 1.0, 0.0),
                 (uv.x + uv.y) * first.x * first.y,
             ); // Yellow line
         }

--- a/shaders/src/two_tweets.rs
+++ b/shaders/src/two_tweets.rs
@@ -6,7 +6,7 @@
 //! // License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
 //! ```
 
-use spirv_std::glam::{Vec2, Vec3, Vec4};
+use spirv_std::glam::{vec3, Vec2, Vec3, Vec4};
 
 // Note: This cfg is incorrect on its surface, it really should be "are we compiling with std", but
 // we tie #[no_std] above to the same condition, so it's fine.
@@ -21,7 +21,7 @@ pub struct Inputs {
 impl Inputs {
     fn f(&self, mut p: Vec3) -> f32 {
         p.z += self.time;
-        (Vec3::splat(0.05 * (9. * p.y * p.x).cos()) + Vec3::new(p.x.cos(), p.y.cos(), p.z.cos())
+        (Vec3::splat(0.05 * (9. * p.y * p.x).cos()) + vec3(p.x.cos(), p.y.cos(), p.z.cos())
             - Vec3::splat(0.1 * (9. * (p.z + 0.3 * p.x - p.y)).cos()))
         .length()
             - 1.
@@ -35,8 +35,8 @@ impl Inputs {
             o += self.f(o) * d;
             i += 1;
         }
-        *c = ((self.f(o - d) * Vec3::new(0.0, 1.0, 2.0)
-            + Vec3::splat(self.f(o - Vec3::splat(0.6))) * Vec3::new(2.0, 1.0, 0.0))
+        *c = ((self.f(o - d) * vec3(0.0, 1.0, 2.0)
+            + Vec3::splat(self.f(o - Vec3::splat(0.6))) * vec3(2.0, 1.0, 0.0))
         .abs()
             * (1. - 0.1 * o.z))
             .extend(1.0);


### PR DESCRIPTION
Glam has short functions for creating Vec2, Vec3, etc... This pull request updates the shaders to use these functions. I feel like this improves readability. There may be some reason to not use these that I am unaware of. Just wanted to see if I could help.

Thanks for putting together this repo!